### PR TITLE
Support Linux

### DIFF
--- a/.github/workflows/workflows/ci.yml
+++ b/.github/workflows/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: "HTTPHeaders CI"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  macos:
+    name: macOS (Xcode ${{ matrix.xcode }})
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode: ["13.4.1", "13.2.1"]
+        include:
+          - xcode: "13.4.1"
+            macos: macOS-12
+          - xcode: "13.2.1"
+            macos: macOS-11
+    runs-on: ${{ matrix.macos }}
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Run Tests
+        run: swift test
+  linux:
+    name: Linux (Swift ${{ matrix.swift }})
+    strategy:
+      fail-fast: false
+      matrix:
+        swift: ["5.5", "5.6"]
+    runs-on: ubuntu-latest
+    container: swift:${{ matrix.swift }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Run Tests
+        run: swift test
+

--- a/Sources/HTTPHeaders/HTTPHeader.swift
+++ b/Sources/HTTPHeaders/HTTPHeader.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public struct HTTPHeader<T> {
     public let field: String

--- a/Tests/HTTPHeadersTests/HTTPHeadersTests.swift
+++ b/Tests/HTTPHeadersTests/HTTPHeadersTests.swift
@@ -1,5 +1,8 @@
-import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import HTTPHeaders
+import XCTest
 
 final class HTTPHeadersTests: XCTestCase {
     func testParseString() throws {


### PR DESCRIPTION
> error: emit-module command failed with exit code 1 (use -v to see invocation)[10/11] Emitting module HTTPHeaders
> /GitHub/.build/checkouts/HTTPHeaders/Sources/HTTPHeaders/HTTPHeader.swift:16:38: error: 'HTTPURLResponse' is unavailable: This type has moved to the FoundationNetworking module. Import that module to use it.